### PR TITLE
Accept buffer and length for BassSource:getFft()

### DIFF
--- a/audio/bass/BassSource.lua
+++ b/audio/bass/BassSource.lua
@@ -106,13 +106,13 @@ function BassSource:getDuration()
 	return length
 end
 
-local fft_values = 128
-local fft_buffer = ffi.new("float[?]", fft_values)
+---@param buffer ffi.cdata*
+---@param length number
 ---@return ffi.cdata*
 ---@return number
-function BassSource:getFft()
-	bass.BASS_ChannelGetData(self.channel, fft_buffer, -2147483648)
-	return fft_buffer, fft_values
+--- Use flags from aqua.bass.fft for length
+function BassSource:getFft(buffer, length)
+	bass.BASS_ChannelGetData(self.channel, buffer, length)
 end
 
 ---@param volume number

--- a/audio/bass/BassSource.lua
+++ b/audio/bass/BassSource.lua
@@ -106,12 +106,17 @@ function BassSource:getDuration()
 	return length
 end
 
+local uptr = ffi.new("uint32_t[1]")
+local sptr = ffi.cast("int32_t*", uptr)
+
 ---@param buffer ffi.cdata*
 ---@param length number
 ---@return ffi.cdata*
 ---@return number
 --- Use flags from aqua.bass.fft for length
 function BassSource:getFft(buffer, length)
+	uptr[0] = length
+	length = sptr[0]
 	bass.BASS_ChannelGetData(self.channel, buffer, length)
 end
 

--- a/bass/fft.lua
+++ b/bass/fft.lua
@@ -1,0 +1,19 @@
+-- BASS_ChannelGetData flags
+return {
+	BASS_DATA_AVAILABLE	= 0, -- query how much data is buffered
+	BASS_DATA_NOREMOVE	= 0x10000000, -- flag: don't remove data from recording buffer
+	BASS_DATA_FLOAT	= 0x40000000, -- flag: return floating-point sample data
+	BASS_DATA_FFT256 = 0x80000000, -- 256 sample FFT
+	BASS_DATA_FFT512 = 0x80000001, -- 512 FFT
+	BASS_DATA_FFT1024 = 0x80000002, -- 1024 FFT
+	BASS_DATA_FFT2048 = 0x80000003, -- 2048 FFT
+	BASS_DATA_FFT4096 = 0x80000004, -- 4096 FFT
+	BASS_DATA_FFT8192 = 0x80000005, -- 8192 FFT
+	BASS_DATA_FFT16384 = 0x80000006, -- 16384 FFT
+	BASS_DATA_FFT32768 = 0x80000007, -- 32768 FFT
+	BASS_DATA_FFT_INDIVIDUAL = 0x10, -- FFT flag: FFT for each channel, else all combined
+	BASS_DATA_FFT_NOWINDOW = 0x20, -- FFT flag: no Hanning window
+	BASS_DATA_FFT_REMOVEDC = 0x40, -- FFT flag: pre-remove DC bias
+	BASS_DATA_FFT_COMPLEX = 0x80, -- FFT flag: return complex data
+	BASS_DATA_FFT_NYQUIST = 0x100, -- FFT flag: return extra Nyquist value
+}

--- a/bass/fft.lua
+++ b/bass/fft.lua
@@ -1,7 +1,7 @@
 -- BASS_ChannelGetData flags
 return {
-	BASS_DATA_AVAILABLE	= 0, -- query how much data is buffered
-	BASS_DATA_NOREMOVE	= 0x10000000, -- flag: don't remove data from recording buffer
+	BASS_DATA_AVAILABLE = 0, -- query how much data is buffered
+	BASS_DATA_NOREMOVE = 0x10000000, -- flag: don't remove data from recording buffer
 	BASS_DATA_FLOAT	= 0x40000000, -- flag: return floating-point sample data
 	BASS_DATA_FFT256 = 0x80000000, -- 256 sample FFT
 	BASS_DATA_FFT512 = 0x80000001, -- 512 FFT

--- a/bass/init.lua
+++ b/bass/init.lua
@@ -80,7 +80,7 @@ QWORD BASS_ChannelSeconds2Bytes(DWORD handle, double pos);
 QWORD BASS_ChannelGetPosition(DWORD handle, DWORD mode);
 BOOL BASS_ChannelGetInfo(DWORD handle, BASS_CHANNELINFO *info);
 QWORD BASS_ChannelGetLength(DWORD handle, DWORD mode);
-DWORD BASS_ChannelGetData(DWORD handle, const void *buffer, DWORD length);
+DWORD BASS_ChannelGetData(DWORD handle, const void *buffer, QWORD length);
 HSAMPLE BASS_SampleLoad(BOOL mem, const void *file, QWORD offset, DWORD length, DWORD max, DWORD flags);
 BOOL BASS_SampleFree(HSAMPLE handle);
 BOOL BASS_ChannelFree(DWORD handle);

--- a/bass/init.lua
+++ b/bass/init.lua
@@ -80,7 +80,7 @@ QWORD BASS_ChannelSeconds2Bytes(DWORD handle, double pos);
 QWORD BASS_ChannelGetPosition(DWORD handle, DWORD mode);
 BOOL BASS_ChannelGetInfo(DWORD handle, BASS_CHANNELINFO *info);
 QWORD BASS_ChannelGetLength(DWORD handle, DWORD mode);
-DWORD BASS_ChannelGetData(DWORD handle, const void *buffer, QWORD length);
+DWORD BASS_ChannelGetData(DWORD handle, const void *buffer, DWORD length);
 HSAMPLE BASS_SampleLoad(BOOL mem, const void *file, QWORD offset, DWORD length, DWORD max, DWORD flags);
 BOOL BASS_SampleFree(HSAMPLE handle);
 BOOL BASS_ChannelFree(DWORD handle);


### PR DESCRIPTION
I need more cool effects and fft 256 is not enough for me. BASS_ChannelGetData accepts length flags with values greater than 2^32, and DWORD is not enough in this case, I changed it to QWORD.