### PR TITLE
Fix not using a correct strategy in recursion

### DIFF
--- a/ui/Node.lua
+++ b/ui/Node.lua
@@ -1,4 +1,5 @@
 local LayoutBox = require("ui.layout.LayoutBox")
+local LayoutEnums = require("aqua.ui.layout.Enums")
 local IInputHandler = require("ui.input.IInputHandler")
 local table_util = require("table_util")
 
@@ -24,6 +25,7 @@ end
 function Node:add(node)
 	---@cast node ui.Node
 	node.parent = self
+	node.layout_box:markDirty(LayoutEnums.Axis.Both)
 	table.insert(self.children, node)
 	return node
 end

--- a/ui/layout/LayoutEngine.lua
+++ b/ui/layout/LayoutEngine.lua
@@ -18,9 +18,9 @@ local GridStrategy = require("ui.layout.strategy.GridStrategy")
 local LayoutEngine = class()
 
 function LayoutEngine:new()
-	self.absolute_strategy = AbsoluteStrategy()
-	self.flex_strategy = FlexStrategy()
-	self.grid_strategy = GridStrategy()
+	self.absolute_strategy = AbsoluteStrategy(self)
+	self.flex_strategy = FlexStrategy(self)
+	self.grid_strategy = GridStrategy(self)
 end
 
 ---@param node ui.Node

--- a/ui/layout/LayoutEngine_test.lua
+++ b/ui/layout/LayoutEngine_test.lua
@@ -379,4 +379,72 @@ function test.intrinsic_size_mixed_with_fixed(t)
 	t:eq(fixed_node.layout_box.x.pos, 64)
 end
 
+---@param t testing.T
+function test.mixed_strategies_tree(t)
+	-- Test a tree with multiple layout strategies at different levels
+	-- Root (Absolute)
+	--   └── flex_container (FlexRow)
+	--         ├── item1
+	--         └── grid_container (Grid)
+	--               ├── grid_item1
+	--               └── grid_item2
+	local engine = LayoutEngine()
+
+	-- Root with absolute layout
+	local root = new_node()
+	root.layout_box:setDimensions(400, 300)
+	root.layout_box.arrange = LayoutBox.Arrange.Absolute
+
+	-- Flex container positioned at (10, 20)
+	local flex_container = root:add(new_node())
+	flex_container.layout_box:setDimensions(200, 200)
+	flex_container.layout_box.arrange = LayoutBox.Arrange.FlexRow
+	flex_container.layout_box.x.pos = 10
+	flex_container.layout_box.y.pos = 20
+
+	-- Item in flex container
+	local item1 = flex_container:add(new_node())
+	item1.layout_box:setDimensions(50, 100)
+
+	-- Grid container as second item in flex
+	local grid_container = flex_container:add(new_node())
+	grid_container.layout_box:setDimensions(100, 100)
+	grid_container.layout_box.arrange = LayoutBox.Arrange.Grid
+	grid_container.layout_box:setGridColumns({50, 50})
+	grid_container.layout_box:setGridRows({50, 50})
+
+	-- Grid items
+	local grid_item1 = grid_container:add(new_node())
+	grid_item1.layout_box:setDimensions(50, 50)
+	grid_item1.layout_box:setGridColumn(1)
+	grid_item1.layout_box:setGridRow(1)
+
+	local grid_item2 = grid_container:add(new_node())
+	grid_item2.layout_box:setDimensions(50, 50)
+	grid_item2.layout_box:setGridColumn(2)
+	grid_item2.layout_box:setGridRow(1)
+
+	engine:updateLayout(root.children)
+
+	-- Flex container should be at (10, 20) (absolute position preserved)
+	t:eq(flex_container.layout_box.x.pos, 10)
+	t:eq(flex_container.layout_box.y.pos, 20)
+
+	-- item1 should be at (0, 0) relative to flex container
+	t:eq(item1.layout_box.x.pos, 0)
+	t:eq(item1.layout_box.y.pos, 0)
+
+	-- grid_container should be at (50, 0) relative to flex container (after item1)
+	t:eq(grid_container.layout_box.x.pos, 50)
+	t:eq(grid_container.layout_box.y.pos, 0)
+
+	-- grid_item1 should be at (0, 0) relative to grid container
+	t:eq(grid_item1.layout_box.x.pos, 0)
+	t:eq(grid_item1.layout_box.y.pos, 0)
+
+	-- grid_item2 should be at (50, 0) relative to grid container (second column)
+	t:eq(grid_item2.layout_box.x.pos, 50)
+	t:eq(grid_item2.layout_box.y.pos, 0)
+end
+
 return test

--- a/ui/layout/strategy/AbsoluteStrategy.lua
+++ b/ui/layout/strategy/AbsoluteStrategy.lua
@@ -113,7 +113,7 @@ function AbsoluteStrategy:arrange(node)
 		child_x.pos = child_x.pos + child_x.margin_start
 		child_y.pos = child_y.pos + child_y.margin_start
 
-		self:arrange(child)
+		self:arrangeChild(child)
 	end
 end
 

--- a/ui/layout/strategy/FlexStrategy.lua
+++ b/ui/layout/strategy/FlexStrategy.lua
@@ -286,7 +286,7 @@ function FlexStrategy:arrange(node)
 
 		child_cross.pos = cross_pos
 
-		self:arrange(child)
+		self:arrangeChild(child)
 
 		pos = pos + child_main.size + child_main:getTotalMargin() + gap
 	end

--- a/ui/layout/strategy/GridStrategy.lua
+++ b/ui/layout/strategy/GridStrategy.lua
@@ -239,7 +239,7 @@ function GridStrategy:arrange(node)
 		child.layout_box.y.pos = y_pos + child.layout_box.y.margin_start
 
 		-- Recurse into children
-		self:arrange(child)
+		self:arrangeChild(child)
 	end
 end
 

--- a/ui/layout/strategy/LayoutStrategy.lua
+++ b/ui/layout/strategy/LayoutStrategy.lua
@@ -4,7 +4,13 @@ local Axis = Enums.Axis
 
 ---@class ui.LayoutStrategy
 ---@operator call: ui.LayoutStrategy
+---@field engine ui.LayoutEngine
 local LayoutStrategy = class()
+
+---@param engine ui.LayoutEngine
+function LayoutStrategy:new(engine)
+	self.engine = engine
+end
 
 ---Measure all children and set node size
 ---@param node ui.Node
@@ -38,6 +44,12 @@ end
 ---@return ui.LayoutAxis
 function LayoutStrategy:getAxis(node, axis_idx)
 	return (axis_idx == Axis.X) and node.layout_box.x or node.layout_box.y
+end
+
+---Arrange a child node using the correct strategy
+---@param node ui.Node
+function LayoutStrategy:arrangeChild(node)
+	self.engine:arrange(node)
 end
 
 return LayoutStrategy


### PR DESCRIPTION
Strategies were arranging items using wrong strategies. This was fixed by delegating this task to the LayoutEngine, previously it was using only one strategy for the entire subtree.